### PR TITLE
Send unhandled ingame messages to events channel

### DIFF
--- a/src/handlers/inGameCommandHandler.js
+++ b/src/handlers/inGameCommandHandler.js
@@ -26,6 +26,7 @@ module.exports = {
         else if (command === `${rustplus.generalSettings.prefix}wipe`) {
             module.exports.commandWipe(rustplus);
         }
+        return false;
     },
 
     commandBradley: function (rustplus) {

--- a/src/rustplusEvents/message.js
+++ b/src/rustplusEvents/message.js
@@ -15,7 +15,14 @@ module.exports = {
             }
             else if (message.broadcast.hasOwnProperty('teamMessage')) {
                 /* Let command handler handle the potential command */
-                CommandHandler.inGameCommandHandler(rustplus, client, message);
+                const handled = CommandHandler.inGameCommandHandler(rustplus, client, message);
+
+                if (handled === false) {
+                    /* If the command was not handled, lets relay to chat */
+                    const { message, name } = message.broadcast.teamMessage.message;
+                    rustplus.sendChatMessage(`${name}: ${message}`);
+                }
+                
             }
             else if (message.broadcast.hasOwnProperty('entityChanged')) {
 

--- a/src/structures/RustPlus.js
+++ b/src/structures/RustPlus.js
@@ -116,6 +116,16 @@ class RustPlus extends RP {
             this.log(text);
         }
     }
+    
+    sendChatMessage(text) {
+        let instance = Client.client.readInstanceFile(this.guildId);
+        let channel = DiscordTools.getTextChannelById(this.guildId, instance.channelId.events);
+
+        if (channel !== undefined) {
+            channel.send(text);
+            this.log(text);
+        }
+    }
 
     getTimeLeftOfTimer(timer) {
         /* Returns the time left of a timer. If timer is not running, null will be returned. */


### PR DESCRIPTION
This adds messages sent in game to the events channel.

This currently only handles if the message was meant to be a command, but allows command responses from the player to goto discord.

