### PR TITLE
Add an option to have "rustPlusPlus | " infront of team chat messages sent by the bot.

### DIFF
--- a/src/discordTools/SetupSettingsMenu.js
+++ b/src/discordTools/SetupSettingsMenu.js
@@ -33,6 +33,20 @@ async function setupGeneralSettings(instance, channel) {
             new MessageAttachment('src/images/settings_logo.png')
         ]
     })
+    await channel.send({
+        embeds: [
+            new MessageEmbed()
+                .setColor('#861c0c')
+                .setTitle('Should a prefix be added to all messages sent by the bot?')
+                .setThumbnail(`attachment://settings_logo.png`)
+        ],
+        components: [
+            DiscordTools.getBotChatPrefixSelectMenu(instance.generalSettings.botchatprefix)
+        ],
+        files: [
+            new MessageAttachment('src/images/settings_logo.png')
+        ]
+    })
 }
 
 async function setupNotificationSettings(instance, channel) {

--- a/src/discordTools/discordTools.js
+++ b/src/discordTools/discordTools.js
@@ -124,6 +124,28 @@ module.exports = {
             );
     },
 
+    getBotChatPrefixSelectMenu: function (currentPrefix) {
+        return new MessageActionRow()
+            .addComponents(
+                new MessageSelectMenu()
+                    .setCustomId('botchatprefix')
+                    .setPlaceholder(`Current Status: ${currentPrefix}`)
+                    .addOptions([
+                        {
+                            label: 'On',
+                            description: 'Put a prefix infront of all bot sent team chat messages.',
+                            value: 'On',
+                        },
+                        {
+                            label: 'Off',
+                            description: 'Have no prefix infront of bot sent team chat messages.',
+                            value: 'Off',
+                        }
+                    ])
+            );
+    },
+
+
     getServerButtonsRow: function (ipPort, state, url) {
         let customId = null;
         let label = null;

--- a/src/handlers/selectMenuHandler.js
+++ b/src/handlers/selectMenuHandler.js
@@ -16,6 +16,17 @@ module.exports = (client, interaction) => {
             let row = DiscordTools.getPrefixSelectMenu(interaction.values[0]);
             interaction.update({ components: [row] });
             break;
+        case 'botchatprefix':
+            instance.generalSettings.botchatprefix = interaction.values[0];
+            client.writeInstanceFile(guildId, instance);
+
+            if (client.rustplusInstances.hasOwnProperty(guildId)) {
+                client.rustplusInstances[guildId].generalSettings.botchatprefix = interaction.values[0];
+            }
+
+            let row2 = DiscordTools.getBotChatPrefixSelectMenu(interaction.values[0]);
+            interaction.update({ components: [row2] });
+            break;
 
         default:
             break;

--- a/src/structures/RustPlus.js
+++ b/src/structures/RustPlus.js
@@ -10,7 +10,12 @@ const DiscordTools = require('../discordTools/discordTools.js');
 class RustPlus extends RP {
     constructor(guildId, serverIp, appPort, steamId, playerToken) {
         super(serverIp, appPort, steamId, playerToken);
+        this.oldsendTeamMessage = this.sendTeamMessage;
+        this.sendTeamMessage = function (message) {
+            let generalSettings = this.generalSettings || { botchatprefix: "On" };
 
+            this.oldsendTeamMessage(`${generalSettings.botchatprefix == "On" ? `rustPlusPlus | ` : ""} ${message}`);
+        }
         this.guildId = guildId;
 
         this.logger = null;

--- a/src/templates/generalSettingsTemplate.json
+++ b/src/templates/generalSettingsTemplate.json
@@ -1,4 +1,5 @@
 {
     "connect": true,
-    "prefix": "!"
+    "prefix": "!",
+    "botchatprefix": "on"
 }

--- a/src/templates/generalSettingsTemplate.json
+++ b/src/templates/generalSettingsTemplate.json
@@ -1,5 +1,5 @@
 {
     "connect": true,
     "prefix": "!",
-    "botchatprefix": "on"
+    "botchatprefix": "On"
 }


### PR DESCRIPTION
This adds a general option to the discord settings channel, and detours the sendTeamMessage function in order to add a prefix depending on the current setting status.