### PR TITLE
fix: handle undefined msg

### DIFF
--- a/src/rustplusEvents/connected.js
+++ b/src/rustplusEvents/connected.js
@@ -74,8 +74,10 @@ module.exports = {
                 instance = client.readInstanceFile(rustplus.guildId);
 
                 let msg = await client.messageSend(infoChannel, { files: [mapFile] });
-                instance.informationMessageId.map = msg.id;
-                client.writeInstanceFile(rustplus.guildId, instance);
+                if (msg) {
+                    instance.informationMessageId.map = msg.id;
+                    client.writeInstanceFile(rustplus.guildId, instance);
+                }
             }
         }
         else {


### PR DESCRIPTION
When you fail to send the message (due to large size), msg is undefined, simply handle that case and don't update the instance file.