### PR TITLE
feat: handle permission error when setting up category & channels

### DIFF
--- a/src/discordTools/SetupGuildCategory.js
+++ b/src/discordTools/SetupGuildCategory.js
@@ -37,10 +37,10 @@ module.exports = async (client, guild) => {
     }
 
     try {
-        category.permissionOverwrites.set(perms);
+        await category.permissionOverwrites.set(perms);
     }
     catch (e) {
-        /* Ignore */
+        client.log('ERROR', `Could not set permissions for category: ${category.id}`, 'error');
     }
 
     return category;

--- a/src/discordTools/SetupGuildChannels.js
+++ b/src/discordTools/SetupGuildChannels.js
@@ -76,11 +76,10 @@ async function addTextChannel(name, client, guild, parent, permissionWrite = fal
 
         perms.push({ id: guild.roles.everyone.id, allow: everyoneAllow, deny: everyoneDeny });
     }
-
     try {
-        channel.permissionOverwrites.set(perms);
+        await channel.permissionOverwrites.set(perms);
     }
     catch (e) {
-        /* Ignore */
+         client.log('ERROR', `Could not set permissions for channel: ${channel.id}`, 'error');
     }
 }


### PR DESCRIPTION
Fixes the following

```js
Unhandled promise rejection: DiscordAPIError[50013]: Missing Permissions
    at SequentialHandler.runRequest (/app/node_modules/@discordjs/rest/dist/lib/handlers/SequentialHandler.cjs:287:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async SequentialHandler.queueRequest (/app/node_modules/@discordjs/rest/dist/lib/handlers/SequentialHandler.cjs:99:14)
    at async REST.request (/app/node_modules/@discordjs/rest/dist/lib/REST.cjs:52:22)
    at async GuildChannelManager.edit (/app/node_modules/discord.js/src/managers/GuildChannelManager.js:262:21) {
  rawError: { message: 'Missing Permissions', code: 50013 },
  code: 50013,
  status: 403,
  method: 'PATCH',
  url: 'https://discord.com/api/v10/channels/929205912508432384',
  requestBody: {
    files: undefined,
    json: {
      name: 'Rust',
      type: undefined,
      topic: undefined,
      nsfw: undefined,
      bitrate: undefined,
      user_limit: undefined,
      rtc_region: undefined,
      video_quality_mode: undefined,
      parent_id: undefined,
      lock_permissions: undefined,
      rate_limit_per_user: undefined,
      default_auto_archive_duration: undefined,
      permission_overwrites: [Array]
    }
  }
}
```