### PR TITLE
feat: server owner messaging

### DIFF
--- a/src/discordTools/discordTools.js
+++ b/src/discordTools/discordTools.js
@@ -46,6 +46,15 @@ module.exports = {
         return undefined;
     },
 
+    getServerOwner:  async guildId => {
+      const guild = module.exports.getGuild(guildId);
+      if (!guild) {
+        return null;
+      }
+    
+      return guild.fetchOwner();
+    },
+
     getTextChannelById: function (guildId, channelId) {
         const guild = module.exports.getGuild(guildId);
 
@@ -253,5 +262,11 @@ module.exports = {
                 }
             }
         }
+    },
+
+    sendOwnerMessage: async(guildId, message) => {
+      const owner = await module.exports.getServerOwner(guildId);
+      if(!owner) return;
+      return owner.send(message);
     },
 }


### PR DESCRIPTION
This adds the ability to send messages to the server owner. This is useful for reminding owners to complete their bot setup, for issues, and even notifications.

For now we use the feature to just send a server setup message that pings the user with details about the created channels, and how to get started with the FCM credentials.


<details>
<summary>Example screenshot</summary>

![image](https://user-images.githubusercontent.com/1134201/196037330-fba9d51d-da75-4f74-bebd-077415fb4257.png)


</details>


### TODO:
- [ ] Localization