### PR TITLE
fix unsupported capitalization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ services:
             - RPP_DISCORD_CLIENT_ID=111....1111
             - RPP_DISCORD_TOKEN=token
         container_name: rpp
-        image: ghcr.io/alexemanuelol/rustPlusPlus
+        image: ghcr.io/alexemanuelol/rustplusplus


### PR DESCRIPTION
Fix for interpretation error I stumbled upon containerizing this on the portainer platform.

**invalid reference format: repository name must be lowercase**