### PR TITLE
Add "needAdminPrivileges" option | Some other fix and package update

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -27,6 +27,7 @@ module.exports = {
     discord: {
         username: process.env.RPP_DISCORD_USERNAME || 'rustPlusPlus',
         clientId: process.env.RPP_DISCORD_CLIENT_ID || '',
-        token: process.env.RPP_DISCORD_TOKEN || ''
+        token: process.env.RPP_DISCORD_TOKEN || '',
+        needAdminPrivileges: process.env.RPP_NEED_ADMIN_PRIVILEGES || true, /* If true, only admins can delete (server, switch..), manage credentials and reset a channel */
     }
 };

--- a/src/commands/credentials.js
+++ b/src/commands/credentials.js
@@ -21,11 +21,12 @@
 const _ = require('lodash');
 const Builder = require('@discordjs/builders');
 
+const Config = require('../../config');
+
 const DiscordEmbeds = require('../discordTools/discordEmbeds.js');
 const DiscordMessages = require('../discordTools/discordMessages.js');
 const DiscordTools = require('../discordTools/discordTools.js');
 const InstanceUtils = require('../util/instanceUtils.js');
-const Config = require('../../config');
 
 module.exports = {
     name: 'credentials',

--- a/src/commands/credentials.js
+++ b/src/commands/credentials.js
@@ -22,7 +22,6 @@ const _ = require('lodash');
 const Builder = require('@discordjs/builders');
 
 const Config = require('../../config');
-
 const DiscordEmbeds = require('../discordTools/discordEmbeds.js');
 const DiscordMessages = require('../discordTools/discordMessages.js');
 const DiscordTools = require('../discordTools/discordTools.js');

--- a/src/commands/credentials.js
+++ b/src/commands/credentials.js
@@ -25,6 +25,7 @@ const DiscordEmbeds = require('../discordTools/discordEmbeds.js');
 const DiscordMessages = require('../discordTools/discordMessages.js');
 const DiscordTools = require('../discordTools/discordTools.js');
 const InstanceUtils = require('../util/instanceUtils.js');
+const Config = require('../../config');
 
 module.exports = {
     name: 'credentials',
@@ -133,7 +134,7 @@ async function addCredentials(client, interaction) {
     const isHoster = interaction.options.getBoolean('host') || Object.keys(credentials).length === 1;
 
     if (Object.keys(credentials) !== 1 && isHoster) {
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             const str = client.intlGet(interaction.guildId, 'missingPermission');
             client.interactionEditReply(interaction, DiscordEmbeds.getActionInfoEmbed(1, str));
             client.log(client.intlGet(null, 'warningCap'), str);
@@ -200,7 +201,7 @@ async function removeCredentials(client, interaction) {
     let steamId = interaction.options.getString('steam_id');
 
     if (steamId && (steamId in credentials) && credentials[steamId].discordUserId !== interaction.member.user.id) {
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             const str = client.intlGet(interaction.guildId, 'missingPermission');
             client.interactionEditReply(interaction, DiscordEmbeds.getActionInfoEmbed(1, str));
             client.log(client.intlGet(null, 'warningCap'), str);
@@ -252,7 +253,7 @@ async function setHosterCredentials(client, interaction) {
     const credentials = InstanceUtils.readCredentialsFile(guildId);
     let steamId = interaction.options.getString('steam_id');
 
-    if (!client.isAdministrator(interaction)) {
+    if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
         const str = client.intlGet(interaction.guildId, 'missingPermission');
         client.interactionEditReply(interaction, DiscordEmbeds.getActionInfoEmbed(1, str));
         client.log(client.intlGet(null, 'warningCap'), str);

--- a/src/commands/reset.js
+++ b/src/commands/reset.js
@@ -20,11 +20,11 @@
 
 const Builder = require('@discordjs/builders');
 
+const Config = require('../../config');
 const DiscordEmbeds = require('../discordTools/discordEmbeds.js');
 const DiscordMessages = require('../discordTools/discordMessages.js');
 const DiscordTools = require('../discordTools/discordTools.js');
 const PermissionHandler = require('../handlers/permissionHandler.js');
-const Config = require('../../config');
 
 module.exports = {
 	name: 'reset',

--- a/src/commands/reset.js
+++ b/src/commands/reset.js
@@ -24,6 +24,7 @@ const DiscordEmbeds = require('../discordTools/discordEmbeds.js');
 const DiscordMessages = require('../discordTools/discordMessages.js');
 const DiscordTools = require('../discordTools/discordTools.js');
 const PermissionHandler = require('../handlers/permissionHandler.js');
+const Config = require('../../config');
 
 module.exports = {
 	name: 'reset',
@@ -63,13 +64,12 @@ module.exports = {
 
 		if (!await client.validatePermissions(interaction)) return;
 
-		if (!client.isAdministrator(interaction)) {
+		if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
 			const str = client.intlGet(interaction.guildId, 'missingPermission');
 			client.interactionReply(interaction, DiscordEmbeds.getActionInfoEmbed(1, str));
 			client.log(client.intlGet(null, 'warningCap'), str);
 			return;
 		}
-
 		await interaction.deferReply({ ephemeral: true });
 
 		const guild = DiscordTools.getGuild(interaction.guildId);

--- a/src/handlers/buttonHandler.js
+++ b/src/handlers/buttonHandler.js
@@ -24,6 +24,7 @@ const SmartSwitchGroupHandler = require('./smartSwitchGroupHandler.js');
 const DiscordButtons = require('../discordTools/discordButtons.js');
 const DiscordModals = require('../discordTools/discordModals.js');
 const Recycler = require('../util/recycler.js');
+const Config = require('../../config');
 
 module.exports = async (client, interaction) => {
     const instance = client.getInstance(interaction.guildId);
@@ -350,7 +351,7 @@ module.exports = async (client, interaction) => {
         const ids = JSON.parse(interaction.customId.replace('ServerDelete', ''));
         const server = instance.serverList[ids.serverId];
 
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             interaction.deferUpdate();
             return;
         }
@@ -439,7 +440,7 @@ module.exports = async (client, interaction) => {
         const ids = JSON.parse(interaction.customId.replace('SmartSwitchDelete', ''));
         const server = instance.serverList[ids.serverId];
 
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             interaction.deferUpdate();
             return;
         }
@@ -487,7 +488,7 @@ module.exports = async (client, interaction) => {
         const ids = JSON.parse(interaction.customId.replace('SmartAlarmDelete', ''));
         const server = instance.serverList[ids.serverId];
 
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             interaction.deferUpdate();
             return;
         }
@@ -559,7 +560,7 @@ module.exports = async (client, interaction) => {
         const ids = JSON.parse(interaction.customId.replace('StorageMonitorToolCupboardDelete', ''));
         const server = instance.serverList[ids.serverId];
 
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             interaction.deferUpdate();
             return;
         }
@@ -607,7 +608,7 @@ module.exports = async (client, interaction) => {
         const ids = JSON.parse(interaction.customId.replace('StorageMonitorContainerDelete', ''));
         const server = instance.serverList[ids.serverId];
 
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             interaction.deferUpdate();
             return;
         }
@@ -624,7 +625,7 @@ module.exports = async (client, interaction) => {
         client.setInstance(guildId, instance);
     }
     else if (interaction.customId === 'RecycleDelete') {
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             interaction.deferUpdate();
             return;
         }
@@ -671,7 +672,7 @@ module.exports = async (client, interaction) => {
         const ids = JSON.parse(interaction.customId.replace('GroupDelete', ''));
         const server = instance.serverList[ids.serverId];
 
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             interaction.deferUpdate();
             return;
         }
@@ -762,7 +763,7 @@ module.exports = async (client, interaction) => {
         const ids = JSON.parse(interaction.customId.replace('TrackerDelete', ''));
         const tracker = instance.trackers[ids.trackerId];
 
-        if (!client.isAdministrator(interaction)) {
+        if (Config.discord.needAdminPrivileges && !client.isAdministrator(interaction)) {
             interaction.deferUpdate();
             return;
         }

--- a/src/handlers/buttonHandler.js
+++ b/src/handlers/buttonHandler.js
@@ -18,13 +18,13 @@
 
 */
 
+const Config = require('../../config');
 const DiscordMessages = require('../discordTools/discordMessages.js');
 const DiscordTools = require('../discordTools/discordTools.js');
 const SmartSwitchGroupHandler = require('./smartSwitchGroupHandler.js');
 const DiscordButtons = require('../discordTools/discordButtons.js');
 const DiscordModals = require('../discordTools/discordModals.js');
 const Recycler = require('../util/recycler.js');
-const Config = require('../../config');
 
 module.exports = async (client, interaction) => {
     const instance = client.getInstance(interaction.guildId);


### PR DESCRIPTION
New option: needAdminPrivileges
Location: config\index.js
Added inside discord bracket.

If true, only admins can delete (server, switch..), manage credentials and reset a channel.

I added this option because on my server. I am the only administrator but I need my friends to be able to delete the switch/server. And reset the channels if there was a problem.


"Remove everything not related to needAdminPrivileges option.

When "const Config = require('../../config');", place it in alphabetic order.

Otherwise looks good 👍"
From [alexemanuelol](https://github.com/alexemanuelol) was patched.