### PR TITLE
Version of Docker and Readme docker capitalization not supported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:18.15.0
 WORKDIR /app
 
 COPY package.json /app/package.json

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ or
 
 ## **Running via docker**
 
-    $ docker run --rm -it -v ${pwd}/credentials:/app/credentials -v ${pwd}/instances:/app/instances -v ${pwd}/logs:/app/logs -e RPP_DISCORD_CLIENT_ID=111....1111 -e RPP_DISCORD_TOKEN=token --name rpp ghcr.io/alexemanuelol/rustPlusPlus
+    $ docker run --rm -it -v ${pwd}/credentials:/app/credentials -v ${pwd}/instances:/app/instances -v ${pwd}/logs:/app/logs -e RPP_DISCORD_CLIENT_ID=111....1111 -e RPP_DISCORD_TOKEN=token --name rpp ghcr.io/alexemanuelol/rustplusplus
 
 or
 


### PR DESCRIPTION
DockerFile version : I removed the "latest" to favor a version that works properly. Because if one day a version of node breaks the application. We will lose a lot of time to find where the error comes from

Reame: Replaced ghcr.io/alexemanuelol/rustPlusPlus by ghcr.io/alexemanuelol/rustplusplus