### PR TITLE
fix docker-publish branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ name: Docker
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:


### PR DESCRIPTION
This should fix publishing an image with the `:master` label. This will allow people to use the bleeding edge of master rather than waiting for a release to be cut.