### PR TITLE
fix: correct arguments for discord event "error"

### DIFF
--- a/src/discordEvents/error.js
+++ b/src/discordEvents/error.js
@@ -20,7 +20,7 @@
 
 module.exports = {
     name: 'error',
-    async execute(client, guild, error) {
+    async execute(client, error) {
         client.log(client.intlGet(null, 'errorCap'), error, 'error');
         process.exit(1);
     },


### PR DESCRIPTION
guild is never actually passed to the error, nor was it used.