### PR TITLE
Battlemetrics Upcoming Wipe v2

### DIFF
--- a/src/discordTools/SetupSettingsMenu.js
+++ b/src/discordTools/SetupSettingsMenu.js
@@ -256,6 +256,17 @@ async function setupGeneralSettings(client, guildId, channel) {
         files: [new Discord.AttachmentBuilder(
             Path.join(__dirname, '..', 'resources/images/settings_logo.png'))]
     });
+    await client.messageSend(channel, {
+        embeds: [DiscordEmbeds.getEmbed({
+            color: Constants.COLOR_SETTINGS,
+            title: client.intlGet(guildId, 'displayInformationBattlemetricsUpcomingWipes'),
+            thumbnail: `attachment://settings_logo.png`
+        })],
+        components: [DiscordButtons.getDisplayInformationBattlemetricsUpcomingWipesButton(guildId,
+            instance.generalSettings.displayInformationBattlemetricsUpcomingWipes)],
+        files: [new Discord.AttachmentBuilder(
+            Path.join(__dirname, '..', 'resources/images/settings_logo.png'))]
+    });
 
     await client.messageSend(channel, {
         embeds: [DiscordEmbeds.getEmbed({

--- a/src/discordTools/discordButtons.js
+++ b/src/discordTools/discordButtons.js
@@ -531,6 +531,16 @@ module.exports = {
                 style: enabled ? SUCCESS : DANGER
             }));
     },
+    getDisplayInformationBattlemetricsUpcomingWipesButton: function (guildId, enabled) {
+        return new Discord.ActionRowBuilder().addComponents(
+            module.exports.getButton({
+                customId: 'DisplayInformationBattlemetricsUpcomingWipes',
+                label: enabled ?
+                    Client.client.intlGet(guildId, 'enabledCap') :
+                    Client.client.intlGet(guildId, 'disabledCap'),
+                style: enabled ? SUCCESS : DANGER
+            }));
+    },
 
     getSubscribeToChangesBattlemetricsButtons: function (guildId) {
         const instance = Client.client.getInstance(guildId);

--- a/src/discordTools/discordEmbeds.js
+++ b/src/discordTools/discordEmbeds.js
@@ -699,6 +699,40 @@ module.exports = {
         const guildId = rustplus.guildId;
         const instance = Client.client.getInstance(guildId);
 
+        const emptyFieldValue = { name: '\u200B', value: '\u200B', inline: true };
+        let firstWipe = emptyFieldValue;
+        let secondWipe = emptyFieldValue;
+
+        const battlemetricsId = instance.activeServer !== null ?
+            instance.serverList[instance.activeServer].battlemetricsId : null;
+
+        if (battlemetricsId && instance.generalSettings.displayInformationBattlemetricsUpcomingWipes){
+            const bmInstance = Client.client.battlemetricsInstances[battlemetricsId];
+            const upcomingWipes = bmInstance.getUpcomingWipesOrderedByTime();
+
+            if (upcomingWipes.length > 0){
+                const closestWipe = upcomingWipes[0];
+                if (closestWipe.type === 'map' || closestWipe.type === 'full') {
+                // try match next map or full wipe
+                const nextMapWipe = upcomingWipes.find((upcoming)=> upcoming.type === 'map')
+                if (nextMapWipe){
+                    firstWipe = { name: Client.client.intlGet(guildId, 'nextMapWipe'), value: `<t:${nextMapWipe.discordTimestamp}:R>`, inline: true}
+                }
+                const nextFullWipe = upcomingWipes.find((upcoming)=> upcoming.type === 'full')
+                if (nextFullWipe){
+                    secondWipe = { name: Client.client.intlGet(guildId, 'nextFullWipe'), value: `<t:${nextFullWipe.discordTimestamp}:R> `, inline: true }
+                }
+                } else {
+                    //if closest wipe is not matched type
+                    firstWipe = {
+                        name: Client.client.intlGet(guildId, 'nextWipe'),
+                        value: `<t:${closestWipe.discordTimestamp}:R> `,
+                        inline: true
+                    }
+                }
+            }
+        }
+
         const time = rustplus.getCommandTime(true);
         const timeLeftTitle = Client.client.intlGet(rustplus.guildId, 'timeTill', {
             event: rustplus.time.isDay() ? Constants.NIGHT_EMOJI : Constants.DAY_EMOJI
@@ -719,18 +753,20 @@ module.exports = {
             fields: [
                 { name: playersFieldName, value: `\`${rustplus.getCommandPop(true)}\``, inline: true },
                 { name: timeFieldName, value: `\`${time[0]}\``, inline: true },
-                { name: wipeFieldName, value: `\`${rustplus.getCommandWipe(true)}\``, inline: true }],
+                time[1] ? { name: timeLeftTitle, value: `\`${time[1]}\``, inline: true } : emptyFieldValue,
+            ],
             timestamp: true
         });
 
         if (time[1] !== null) {
             embed.addFields(
-                { name: timeLeftTitle, value: `\`${time[1]}\``, inline: true },
-                { name: '\u200B', value: '\u200B', inline: true },
-                { name: '\u200B', value: '\u200B', inline: true });
+                { name: wipeFieldName, value: `\`${rustplus.getCommandWipe(true)}\``, inline: true },
+                firstWipe,
+                secondWipe,
+                );
         }
         else {
-            embed.addFields({ name: '\u200B', value: '\u200B', inline: false });
+            embed.addFields(emptyFieldValue);
         }
 
         embed.addFields(

--- a/src/handlers/buttonHandler.js
+++ b/src/handlers/buttonHandler.js
@@ -340,6 +340,24 @@ module.exports = async (client, interaction) => {
                 instance.generalSettings.displayInformationBattlemetricsAllOnlinePlayers)]
         });
     }
+    else if (interaction.customId === 'DisplayInformationBattlemetricsUpcomingWipes') {
+        instance.generalSettings.displayInformationBattlemetricsUpcomingWipes =
+            !instance.generalSettings.displayInformationBattlemetricsUpcomingWipes;
+        client.setInstance(guildId, instance);
+
+        if (rustplus) rustplus.generalSettings.displayInformationBattlemetricsUpcomingWipes =
+            instance.generalSettings.displayInformationBattlemetricsUpcomingWipes;
+
+        client.log(client.intlGet(null, 'infoCap'), client.intlGet(null, 'buttonValueChange', {
+            id: `${verifyId}`,
+            value: `${instance.generalSettings.displayInformationBattlemetricsUpcomingWipes}`
+        }));
+
+        await client.interactionUpdate(interaction, {
+            components: [DiscordButtons.getDisplayInformationBattlemetricsUpcomingWipesButton(guildId,
+                instance.generalSettings.displayInformationBattlemetricsUpcomingWipes)]
+        });
+    }
     else if (interaction.customId === 'BattlemetricsServerNameChanges') {
         instance.generalSettings.battlemetricsServerNameChanges =
             !instance.generalSettings.battlemetricsServerNameChanges;

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -766,5 +766,8 @@
     "wipeDetected": "Wipe detected!",
     "yield": "Yield",
     "youAreAlreadyLeader": "You are already leader.",
-    "youAreNotPairedWithServer": "Leader command does not work because you're not paired with the server."
+    "nextFullWipe": "Next full wipe",
+    "nextMapWipe": "Next map wipe",
+    "nextWipe": "Next wipe",
+    "displayInformationBattlemetricsUpcomingWipes": "Should be closest wipe from Battlemetrics be displayed in the information channel?"
 }

--- a/src/structures/Battlemetrics.js
+++ b/src/structures/Battlemetrics.js
@@ -106,6 +106,7 @@ class Battlemetrics {
         this.server_rust_last_wipe = null;
         this.server_rust_last_wipe_ent = null;
         this.server_serverSteamId = null;
+        this.server_rust_wipes = null;
         this.map_url = null;
         this.map_thumbnailUrl = null;
         this.map_monuments = null;
@@ -153,6 +154,7 @@ class Battlemetrics {
     set offlinePlayers(offlinePlayers) { this._offlinePlayers = offlinePlayers; }
     get serverEvaluation() { return this._serverEvaluation; }
     set serverEvaluation(serverEvaluation) { this._serverEvaluation = serverEvaluation; }
+    get rustWipes() { return this.server_rust_wipes; }
 
     /**
      *  Construct the Battlemetrics API call for searching servers by name.
@@ -725,6 +727,7 @@ class Battlemetrics {
         this.server_rust_last_wipe = details.rust_last_wipe;
         this.server_rust_last_wipe_ent = details.rust_last_wipe_ent;
         this.server_serverSteamId = details.serverSteamId;
+        this.server_rust_wipes = details.rust_wipes
 
         const rustMaps = details.rust_maps;
         if (rustMaps) {
@@ -799,6 +802,18 @@ class Battlemetrics {
         }
         let ordered = unordered.sort(function (a, b) { return a[0] - b[0] })
         return ordered.map(e => e[1]);
+    }
+
+    getUpcomingWipesOrderedByTime() {
+        const unordered = [];
+        for (const wipe of this.rustWipes) {
+            const timestampDate =  new Date(wipe.timestamp)
+            wipe.discordTimestamp = timestampDate.getTime() / 1000;
+            const timestampSplit = timestampDate.toISOString().split('T')
+            wipe.readableTimestamp = timestampSplit.length === 2 ?`${timestampSplit[0]} T ${timestampSplit[1]}`: timestampDate.toISOString()
+            unordered.push(wipe);
+        }
+        return unordered.sort(function (a, b) { return a.discordTimestamp - b.discordTimestamp })
     }
 
     /**

--- a/src/templates/generalSettingsTemplate.json
+++ b/src/templates/generalSettingsTemplate.json
@@ -18,6 +18,7 @@
     "mapWipeNotifyEveryone": false,
     "itemAvailableInVendingMachineNotifyInGame": true,
     "displayInformationBattlemetricsAllOnlinePlayers": false,
+    "displayInformationBattlemetricsUpcomingWipes": false,
     "battlemetricsServerNameChanges": true,
     "battlemetricsTrackerNameChanges": true,
     "battlemetricsGlobalNameChanges": false,

--- a/src/util/CreateInstanceFile.js
+++ b/src/util/CreateInstanceFile.js
@@ -51,7 +51,8 @@ module.exports = (client, guild) => {
                 server: null,
                 event: null,
                 team: null,
-                battlemetricsPlayers: null
+                battlemetricsPlayers: null,
+                battlemetricsUpcomingWipes:null
             },
             activeServer: null,
             serverList: {},
@@ -153,7 +154,8 @@ module.exports = (client, guild) => {
                 server: null,
                 event: null,
                 team: null,
-                battlemetricsPlayers: null
+                battlemetricsPlayers: null,
+                battlemetricsUpcomingWipes:null
             }
         }
         else {


### PR DESCRIPTION
I remade showing of upcoming wipes based on discord and previous PR comments (https://github.com/alexemanuelol/rustplusplus/pull/302)

There is no longer own embed showing all upcoming wipes but only closest wipe. If wipe got type `map` or `full` it will show as map or full wipe: 

![upcomingWipeKnownWipes](https://github.com/alexemanuelol/rustplusplus/assets/49523614/8ef15942-857e-435a-9810-67f24b0901dd)

If closest wipe is not type `map` or `full` or none of these types is found then closest wipe with any type will be shown (atm. can be type `unknown`)

![upcomingWipeUnknown](https://github.com/alexemanuelol/rustplusplus/assets/49523614/f78a809c-5063-4f01-899e-c5ade43b20f0)


Whole functionality can be turn on/off in settings (default: off)

