### PR TITLE
Separate Small and Large Oil Rig notification settings

### DIFF
--- a/docs/full_list_features.md
+++ b/docs/full_list_features.md
@@ -85,7 +85,7 @@
 > Receive notifications for In-Game Events such as:
 - **Cargo Ship** - When it spawns, despawns, how long before it enters egress stage. How long time since it was last out. step-trace.
 - **Patrol Helicopter** - When it spawns, despawns or gets taken down. How long time since it was last out and how long since it was taken down. step-trace.
-- **Oil Rig** - When Oil Rig calls in Heavy Scientists and how long till the Locked Crate unlocks.
+- **Oil Rigs** - When Heavy Scientists are called at each, and how long until the Locked Crates unlock.
 - **Chinook 47** - When it enters map and when it leaves.
 - **Vending Machines** - Whenever a new Vending Machine appears on the map.
 

--- a/src/structures/MapMarkers.js
+++ b/src/structures/MapMarkers.js
@@ -362,7 +362,7 @@ class MapMarkers {
                         marker.ch47Type = 'smallOilRig';
 
                         this.rustplus.sendEvent(
-                            this.rustplus.notificationSettings.heavyScientistCalledSetting,
+                            this.rustplus.notificationSettings.heavyScientistCalledSmallSetting,
                             this.client.intlGet(this.rustplus.guildId, 'heavyScientistsCalledSmall',
                                 { location: oilRigLocation.location }),
                             'small',
@@ -397,7 +397,7 @@ class MapMarkers {
                         marker.ch47Type = 'largeOilRig';
 
                         this.rustplus.sendEvent(
-                            this.rustplus.notificationSettings.heavyScientistCalledSetting,
+                            this.rustplus.notificationSettings.heavyScientistCalledLargeSetting,
                             this.client.intlGet(this.rustplus.guildId, 'heavyScientistsCalledLarge',
                                 { location: oilRigLocation.location }),
                             'large',
@@ -688,7 +688,7 @@ class MapMarkers {
         let oilRigLocation = args[0];
 
         this.rustplus.sendEvent(
-            this.rustplus.notificationSettings.lockedCrateOilRigUnlockedSetting,
+            this.rustplus.notificationSettings.lockedCrateOilRigUnlockedSmallSetting,
             this.client.intlGet(this.rustplus.guildId, 'lockedCrateSmallOilRigUnlocked', {
                 location: oilRigLocation
             }),
@@ -706,7 +706,7 @@ class MapMarkers {
         let oilRigLocation = args[0];
 
         this.rustplus.sendEvent(
-            this.rustplus.notificationSettings.lockedCrateOilRigUnlockedSetting,
+            this.rustplus.notificationSettings.lockedCrateOilRigUnlockedLargeSetting,
             this.client.intlGet(this.rustplus.guildId, 'lockedCrateLargeOilRigUnlocked', {
                 location: oilRigLocation
             }),

--- a/src/templates/notificationSettingsTemplate.json
+++ b/src/templates/notificationSettingsTemplate.json
@@ -35,14 +35,26 @@
         "inGame": false,
         "voice": true
     },
-    "lockedCrateOilRigUnlockedSetting": {
-        "image": "locked_crate_logo.png",
+    "heavyScientistCalledSmallSetting": {
+        "image": "small_oil_rig_logo.png",
         "discord": true,
         "inGame": false,
         "voice": true
     },
-    "heavyScientistCalledSetting": {
-        "image": "oil_rig_logo.png",
+    "lockedCrateOilRigUnlockedSmallSetting": {
+        "image": "locked_crate_small_oil_rig_logo.png",
+        "discord": true,
+        "inGame": false,
+        "voice": true
+    },
+    "heavyScientistCalledLargeSetting": {
+        "image": "large_oil_rig_logo.png",
+        "discord": true,
+        "inGame": false,
+        "voice": true
+    },
+    "lockedCrateOilRigUnlockedLargeSetting": {
+        "image": "locked_crate_large_oil_rig_logo.png",
         "discord": true,
         "inGame": false,
         "voice": true


### PR DESCRIPTION
Also slightly re-order settings options to be more chronological, i.e. Heavy Scientists notification setting now comes before the Locked Crate unlock notification setting.