### PR TITLE
Include multi-architecture docker image generation in docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -59,3 +65,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Add multi-architecture docker image generation including arm64 to `docker-publish.yml`.

* Add `docker/setup-qemu-action@v2` to set up QEMU for emulating different CPU architectures.
* Add `docker/setup-buildx-action@v2` to set up Docker Buildx for multi-architecture builds.
* Specify `platforms: linux/amd64,linux/arm64` in the `docker/build-push-action@v6` step to include arm64 architecture.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alexemanuelol/rustplusplus?shareId=XXXX-XXXX-XXXX-XXXX).