### PR TITLE
chore(lint): update node version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,9 @@ jobs:
     name: Lint - Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node: [ 14, 16, 18 ]
+        node: [ 18, 20, 22 ]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
Removes failing version, additionally continues even on first fail (allowing others to be tested)