### PR TITLE
feat: allow updating credentials without removing existing

### DIFF
--- a/src/commands/credentials.js
+++ b/src/commands/credentials.js
@@ -125,13 +125,6 @@ async function addCredentials(client, interaction, verifyId) {
         }
     }
 
-    if (steamId in credentials) {
-        const str = client.intlGet(guildId, 'credentialsAlreadyRegistered', { steamId: steamId });
-        await client.interactionEditReply(interaction, DiscordEmbeds.getActionInfoEmbed(1, str));
-        client.log(client.intlGet(null, 'warningCap'), str);
-        return;
-    }
-
     credentials[steamId] = new Object();
     credentials[steamId].gcm = new Object();
     credentials[steamId].gcm.android_id = interaction.options.getString('gcm_android_id');

--- a/src/commands/credentials.js
+++ b/src/commands/credentials.js
@@ -125,6 +125,22 @@ async function addCredentials(client, interaction, verifyId) {
         }
     }
 
+    // Clean up existing listeners if there are any.
+    if (steamId in credentials) {
+        if (steamId === credentials.hoster) {
+            if (client.fcmListeners[guildId]) {
+                client.fcmListeners[guildId].destroy();
+            }
+            delete client.fcmListeners[guildId];
+            credentials.hoster = null;
+        } else {
+            if (client.fcmListenersLite[guildId][steamId]) {
+                client.fcmListenersLite[guildId][steamId].destroy();
+            }
+            delete client.fcmListenersLite[guildId][steamId];
+        }
+    }
+    
     credentials[steamId] = new Object();
     credentials[steamId].gcm = new Object();
     credentials[steamId].gcm.android_id = interaction.options.getString('gcm_android_id');


### PR DESCRIPTION
The check to avoid adding credentials twice was more just in the way forcing you to remove then add.
If you add twice, we now delete beforehand.